### PR TITLE
feature: add commitizen config

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,7 @@
+[tool.commitizen]
+name = "cz_jira"
+tag_format = "$version"
+version_scheme = "semver"
+version_provider = "npm"
+update_changelog_on_bump = true
+major_version_zero = true

--- a/.github/workflows/bumpversion.yaml
+++ b/.github/workflows/bumpversion.yaml
@@ -1,0 +1,30 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump-version:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: "Bump version and create changelog with commitizen"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          changelog_increment_filename: body.md
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "body.md"
+          tag_name: ${{ env.REVISION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have configured the Commitizen GitHub action, as I think the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and [semantic versioning](https://semver.org/) that Commitizen enforces is a good practice in terms of software release.