### PR TITLE
chore(action): add working directory when configuring commitizen action

### DIFF
--- a/.github/workflows/bumpversion.yaml
+++ b/.github/workflows/bumpversion.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: frontend/
           changelog_increment_filename: body.md
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This pull request modifies the workflow file for the Commitizen GitHub action, specifying a working directory for the action.