### PR TITLE
Fix dynamic status bar color management

### DIFF
--- a/frontend/src/app/(protected)/(tabs)/(home)/index.jsx
+++ b/frontend/src/app/(protected)/(tabs)/(home)/index.jsx
@@ -3,6 +3,7 @@ import { useQueries } from "@tanstack/react-query";
 import * as Location from "expo-location";
 import _ from "lodash";
 import { useEffect } from "react";
+import { useStatusBarStyle } from "~/utils/useStatusBarStyle";
 import { useState } from "react";
 import { useRef } from "react";
 import {
@@ -33,6 +34,8 @@ import CityRules from "../../../../components/curbside/CityRules";
 import { Dropdown } from "react-native-element-dropdown";
 
 const CurbsideDropoff = () => {
+  useStatusBarStyle("light");
+
   const navigation = useNavigation();
   const {
     itemsRecycled,

--- a/frontend/src/app/(protected)/(tabs)/_layout.jsx
+++ b/frontend/src/app/(protected)/(tabs)/_layout.jsx
@@ -7,7 +7,6 @@ import Custombar from "~/components/navigation/Custombar";
 export default function BottomTabsLayout() {
   return (
     <Tabs
-      // screenOptions={{ headerShown: false, statusBarStyle: "inverted", }}
       screenOptions={{ headerShown: false }}
       tabBar={(props) => <Custombar {...props} />}
       backBehavior="order"

--- a/frontend/src/app/(protected)/(tabs)/about.jsx
+++ b/frontend/src/app/(protected)/(tabs)/about.jsx
@@ -2,6 +2,7 @@ import Entypo from "@expo/vector-icons/Entypo";
 import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 import { Link } from "expo-router";
 import { useEffect, useState } from "react";
+import { useStatusBarStyle } from "~/utils/useStatusBarStyle";
 import { Dimensions, ScrollView, StyleSheet, Text, View } from "react-native";
 import { AboutCalendar } from "./calendar";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -23,6 +24,8 @@ function calcWidth(size) {
 }
 
 export default function About() {
+  useStatusBarStyle("dark");
+
   const [num, setNum] = useState(0);
   useEffect(() => {
     const interval = setInterval(() => {

--- a/frontend/src/app/(protected)/(tabs)/camera.jsx
+++ b/frontend/src/app/(protected)/(tabs)/camera.jsx
@@ -4,6 +4,7 @@ import * as FileSystem from "expo-file-system";
 import { Image } from "expo-image";
 import * as ImagePicker from "expo-image-picker";
 import { useEffect, useState } from "react";
+import { useStatusBarStyle } from "~/utils/useStatusBarStyle";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import CameraScan from "~/components/camera/CameraScan";
 import ItemScanInstructions from "~/components/camera/ItemScanInstructions";
@@ -16,6 +17,8 @@ import _ from "lodash";
 import { useQueries } from "@tanstack/react-query";
 
 export default function ItemScan() {
+  useStatusBarStyle("light");
+
   const navigation = useNavigation();
   const [image, setImage] = useState(null);
   const [accepted, setAccepted] = useState(false);

--- a/frontend/src/app/(protected)/(tabs)/profile/index.jsx
+++ b/frontend/src/app/(protected)/(tabs)/profile/index.jsx
@@ -2,6 +2,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import * as ImagePicker from "expo-image-picker";
 import { useContext, useEffect, useState } from "react";
+import { useStatusBarStyle } from "~/utils/useStatusBarStyle";
 import { Link } from "expo-router";
 import Svg, { Path } from 'react-native-svg';
 import {
@@ -33,6 +34,8 @@ import { doc, setDoc, getDoc } from "firebase/firestore";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function UserAccount() {
+  useStatusBarStyle("dark");
+
   const {
     itemsRecycled,
     setItemsRecycled,

--- a/frontend/src/app/(protected)/_layout.jsx
+++ b/frontend/src/app/(protected)/_layout.jsx
@@ -2,7 +2,6 @@ import { Redirect, Stack } from "expo-router";
 import { useContext, useMemo } from "react";
 import { AuthContext } from "~/utils/authContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { setStatusBarStyle } from "expo-status-bar";
 
 export const unstable_settings = {
   initialRouteName: "(tabs)", // anchor

--- a/frontend/src/app/_layout.jsx
+++ b/frontend/src/app/_layout.jsx
@@ -1,5 +1,4 @@
 import { Stack } from "expo-router";
-import { StatusBar } from "expo-status-bar";
 import { AuthProvider } from "~/utils/authContext";
 import { RecyclingProvider } from "../utils/recyclingContext";
 
@@ -7,8 +6,6 @@ export default function RootLayout() {
   return (
     <AuthProvider>
       <RecyclingProvider>
-        {/* <StatusBar style="auto" /> */}
-        <StatusBar style="dark" />
         <Stack screenOptions={{ headerShown: false, animation: "none" }}>
           <Stack.Screen name="(protected)" />
           <Stack.Screen name="login" />

--- a/frontend/src/app/login.jsx
+++ b/frontend/src/app/login.jsx
@@ -10,12 +10,15 @@ import {
   View,
 } from "react-native";
 import { AuthContext } from "~/utils/authContext";
+import { useStatusBarStyle } from "~/utils/useStatusBarStyle";
 import Divider from "~/components/common/Divider";
 import { normalize } from "~/utils/normalize";
 import {useRouter} from "expo-router"
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function LoginScreen() {
+  useStatusBarStyle("light");
+
   const authContext = useContext(AuthContext);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/frontend/src/utils/useStatusBarStyle.js
+++ b/frontend/src/utils/useStatusBarStyle.js
@@ -1,0 +1,11 @@
+import { useCallback } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { setStatusBarStyle } from "expo-status-bar";
+
+export function useStatusBarStyle(style) {
+  useFocusEffect(
+    useCallback(() => {
+      setStatusBarStyle(style);
+    }, [style])
+  );
+}


### PR DESCRIPTION
Status bar icons now properly switch between light and dark colors depending on the active screen (light for Home, Camera, and Login, dark for About and Profile).
<img width="329" height="168" alt="image" src="https://github.com/user-attachments/assets/2ecc816d-7973-4f2a-a9d0-1599a68df321" />
<img width="316" height="118" alt="image" src="https://github.com/user-attachments/assets/d457d448-62ea-4734-822b-ea9b158aae4d" />

## Summary by Sourcery

Introduce per-screen control of status bar icon color based on navigation focus and remove global status bar configuration from layouts.

New Features:
- Add a reusable useStatusBarStyle hook that updates the status bar style when a screen gains focus.

Enhancements:
- Apply light or dark status bar styles on Login, Home, Camera, About, and Profile screens to match their respective UI designs and improve readability.